### PR TITLE
absorptive2dPP.m and minor OO updates

### DIFF
--- a/OO_workspace/load2DIRdata.m
+++ b/OO_workspace/load2DIRdata.m
@@ -57,12 +57,16 @@ for ii = 1:ndirs
         output(scanoffset + jj) = m.data;
     end
     for jj = scanlist_holder
-        output(scanoffset + jj).scan_number = scanoffset + jj;
-        output(scanoffset + jj).datestring = datestring{scanoffset + jj};
+        output_(scanoffset + jj).scan_number = jj;
+        output_(scanoffset + jj).datestring = datestring{scanoffset + jj};
 %         data(scanoffset + jj).name = name;
 %         data(scanoffset + jj).temperature = temperature;
     end
     scanoffset = length(output); %Now I see it. This allows us to splice together 
     % different days into the same array, without loss of indexing.
+    cd(old_dir);
 end
-cd(old_dir);
+for ii = 1:length(output)
+    output(ii).scan_number = output_(ii).scan_number;
+    output(ii).datestring = output_(ii).datestring;
+end

--- a/OO_workspace/sort2DIRdata.m
+++ b/OO_workspace/sort2DIRdata.m
@@ -13,14 +13,25 @@ function output = sort2DIRdata(input,varargin)
 %      data = sort2DIRdata(data,'sortby','scan_number');
 %
 % will sort the structure by the field 'scan_number'
+%
+% Using the 'mode' variable argument will allow you to sort either
+% ascending or descending.
 
 sort_field = 't2';
+sort_mode = 'ascend';
 while length(varargin)>=2 %using a named pair
   arg = varargin{1};
   val = varargin{2};
   switch lower(arg)
+    case 'mode'
+        if strcmp(val,'ascend')||strcmp(val,'descend')
+        sort_mode = val;
+        else
+            warning(['Unknown sorting method: ',val,'. Sorting by ascending order'])
+            sort_mode = 'ascend';
+        end
     case 'sortby'
-    sort_field = val;
+        sort_field = val;
     if ~isfield(input,val)
         warning(['Unknown field to sort by',arg,'Sorting by t2'])
         sort_field = 't2';
@@ -34,5 +45,5 @@ end
 empty_elems = arrayfun(@(s) all(structfun(@isempty,s)),input);
 temp = input(~empty_elems);
 uh = [temp.(sort_field)];
-[~,ind] = sort(uh);
+[~,ind] = sort(uh,sort_mode);
 output = temp(ind);

--- a/absorptive2dPP.m
+++ b/absorptive2dPP.m
@@ -180,7 +180,7 @@ if flag_spectrometer
   end
 
   %correct for the phase calculated by the phasing routine
-  R = -real(R.*exp(-1i*phase*pi/180));
+  R = real(R.*exp(-1i*phase*pi/180));
   R = fftshift(R,2);
   
 %   if flag_remove_DC


### PR DESCRIPTION
**Fixed a sign error that was in our copies of absorptive2dPP.m, and was causing the sign of our 2D-IR spectra to flip when we processed them locally.**
line 183
old: `R = -real(R.*exp(-1i*phase*pi/180));`
new: `R = real(R.*exp(-1i*phase*pi/180));`

Fixed an error in the 'load2DIRdata.m' where we were not handling loading from multiple directories correctly.

Added functionality to 'sort2DIRdata.m' to allow us to sort by a field of choice, not just by t2.